### PR TITLE
Make setters private

### DIFF
--- a/src/hillbillies/model/Unit.java
+++ b/src/hillbillies/model/Unit.java
@@ -132,4 +132,5 @@ public class Unit {
 	 */
 	private int toughness;
 	
+	
 }


### PR DESCRIPTION
No reason so far to make the implementation of these setters available
to clients of the Unit class.
